### PR TITLE
Fix native name for Finnish language

### DIFF
--- a/js/i18n.js
+++ b/js/i18n.js
@@ -3,7 +3,7 @@ const lngs = {
     'en-US': { nativeName: 'English (US)' },
     de: { nativeName: 'Deutsch' },
     es: { nativeName: 'Español' },
-    'fi-FI': { nativeName: 'Suorittaa loppuun (FI)' },
+    'fi-FI': { nativeName: 'Suomi (FI)' },
     'it-IT': { nativeName: 'Italiano (IT)' },
     fr: { nativeName: 'Français' },
     'nb-NO': { nativeName: 'Norsk (NO)' },


### PR DESCRIPTION
The current version was a direct translation of the English verb "finish" in infinitive form. This new version is the real name of the Finnish language in Finnish.